### PR TITLE
Fix support of torch tensors on CUDA

### DIFF
--- a/src/geom_median/torch/main.py
+++ b/src/geom_median/torch/main.py
@@ -17,16 +17,17 @@ def compute_geometric_median(
 		raise ValueError(
 			f"We expect `points` as a list of arrays or a list of tuples of arrays. Got {type(points)}"
 		)
-	if weights is None:
-		n = len(points)
-		weights = torch.ones(n)
 	if type(points[0]) == torch.Tensor: # `points` are given in list of arrays format
 		if not skip_typechecks:
 			utils.check_list_of_array_format(points)
+		if weights is None:
+			weights = torch.ones(len(points), device=points[0].device)
 		to_return = geometric_median_array(points, weights, eps, maxiter, ftol)
 	elif type(points[0]) in [list, tuple]: # `points` are in list of list of arrays format
 		if not skip_typechecks:
 			utils.check_list_of_list_of_array_format(points)
+		if weights is None:
+			weights = torch.ones(len(points), device=points[0][0].device)
 		if per_component:
 			to_return = geometric_median_per_component(points, weights, eps, maxiter, ftol)
 		else:

--- a/src/geom_median/torch/weiszfeld_array.py
+++ b/src/geom_median/torch/weiszfeld_array.py
@@ -81,4 +81,4 @@ def weighted_average(points, weights):
 
 @torch.no_grad()
 def geometric_median_objective(median, points, weights):
-    return np.average([torch.linalg.norm((p - median).reshape(-1)).item() for p in points], weights=weights)
+    return np.average([torch.linalg.norm((p - median).reshape(-1)).item() for p in points], weights=weights.cpu())

--- a/src/geom_median/torch/weiszfeld_list_of_array.py
+++ b/src/geom_median/torch/weiszfeld_list_of_array.py
@@ -58,7 +58,7 @@ def weighted_average(points, weights):
 
 @torch.no_grad()
 def geometric_median_objective(median, points, weights):
-    return np.average([l2distance(p, median).item() for p in points], weights=weights)
+    return np.average([l2distance(p, median).item() for p in points], weights=weights.cpu())
 
 @torch.no_grad()
 def l2distance(p1, p2):


### PR DESCRIPTION
Thank you for the paper and for creating this small convenient library!

There are two bugs preventing using `compute_geometric_median()` function from `geom_median.torch` with `points` being a CUDA tensor (at least on PyTorch 1.9.0):

1. If we don't pass `weights` at all, it will use `torch.ones()` to create a CPU tensor and won't be able to mix it with CUDA tensors during the calculations. Same with passing `weights` on CPU.

    ```python
    /mnt/downloads/geom_median/src/geom_median/torch/weiszfeld_array.py in geometric_median_array(points, weights, eps, maxiter, ftol)
         30             norms = torch.stack([torch.linalg.norm((p - median).view(-1)) for p in points])
    ---> 31             new_weights = weights / torch.clamp(norms, min=eps)
    
    RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
    ```

2. If we pass `weights` on CUDA, it won't be able to use it in `np.average()`:

    ```python
    /mnt/downloads/geom_median/src/geom_median/torch/weiszfeld_array.py in geometric_median_objective(median, points, weights)
    ---> 84     return np.average([torch.linalg.norm((p - median).reshape(-1)).item() for p in points], weights=weights)
    
    TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
    ```

This PR fixes both these bugs, so it works fine if you either pass `weights` as a CUDA tensor (located on the same device as `points`) or don't pass `weights` at all.